### PR TITLE
Add fallback to browser is secp256k1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "0.10"
 addons:
   firefox: "34.0"
+env:
+  - ECCRYPTO_NO_FALLBACK=1
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - "0.10"
 addons:
   firefox: "34.0"
-env:
-  - ECCRYPTO_NO_FALLBACK=1
 notifications:
   email:
     on_success: never

--- a/browser.js
+++ b/browser.js
@@ -7,7 +7,7 @@
 var EC = require("elliptic").ec;
 
 var ec = new EC("secp256k1");
-var cryptoObj = window.crypto || window.msCrypto || {};
+var cryptoObj = global.crypto || global.msCrypto || {};
 var subtle = cryptoObj.subtle || cryptoObj.webkitSubtle;
 
 function assert(condition, message) {
@@ -18,7 +18,7 @@ function assert(condition, message) {
 
 function randomBytes(size) {
   var arr = new Uint8Array(size);
-  window.crypto.getRandomValues(arr);
+  global.crypto.getRandomValues(arr);
   return new Buffer(arr);
 }
 

--- a/index.js
+++ b/index.js
@@ -12,10 +12,14 @@ var crypto = require("crypto");
 // try to use secp256k1, fallback to browser implementation
 try {
   var secp256k1 = require("secp256k1");
+  var ecdh = require("./build/Release/ecdh");
 } catch (e) {
-  return (module.exports = require("./browser"));
+  if (process.env.ECCRYPTO_NO_FALLBACK) {
+    throw e;
+  } else {
+    return (module.exports = require("./browser"));
+  }
 }
-var ecdh = require("./build/Release/ecdh");
 
 function assert(condition, message) {
   if (!condition) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var crypto = require("crypto");
 try {
   var secp256k1 = require("secp256k1");
 } catch (e) {
-  return module.exports = require("./browser");
+  return (module.exports = require("./browser"));
 }
 var ecdh = require("./build/Release/ecdh");
 

--- a/index.js
+++ b/index.js
@@ -9,9 +9,12 @@ var promise = typeof Promise === "undefined" ?
               require("es6-promise").Promise :
               Promise;
 var crypto = require("crypto");
-// TODO(Kagami): We may fallback to pure JS implementation
-// (`browser.js`) if this modules are failed to load.
-var secp256k1 = require("secp256k1");
+// try to use secp256k1, fallback to browser implementation
+try {
+  var secp256k1 = require("secp256k1");
+} catch (e) {
+  return module.exports = require("./browser");
+}
 var ecdh = require("./build/Release/ecdh");
 
 function assert(condition, message) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "browser.js",
   "scripts": {
     "install": "node-gyp rebuild || exit 0",
-    "test": "mocha && xvfb-run -a karma start && jshint .",
+    "test": "ECCRYPTO_NO_FALLBACK=1 mocha && xvfb-run -a karma start && jshint .",
     "m": "mocha",
     "k": "xvfb-run -a karma start",
     "kc": "xvfb-run -a karma start --browsers Chromium",


### PR DESCRIPTION
This makes eccrypto fall back to the elliptic implementation if `secp256k1` fails to load (which it will on Windows).

This seems to be working well for me. All the browser tests pass and all the node tests pass even when using the browser implementation. The small exception is that the ECIES tests fail in the node tests, when falling back to the browser implementation with "WebCryptoAPI is not available".