### PR TITLE
stop displaying a long error when reverting to browser version

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,7 @@ try {
   if (process.env.ECCRYPTO_NO_FALLBACK) {
     throw e;
   } else {
-    console.error(e);
-    console.error('Reverting to browser version');
+    console.info('secp256k1 unavailable, reverting to browser version');
     return (module.exports = require("./browser"));
   }
 }


### PR DESCRIPTION
There is no point on displaying a very long error message, this is not an error, it's a normal fallback