### PR TITLE
Support react-native

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -47,7 +47,10 @@ not, since the functions are different and does
 not convert using browserify */
 function randomBytes(size) {
   var arr = new Uint8Array(size);
-  if (typeof window === 'undefined') {
+  if (
+    typeof browserCrypto === 'undefined' ||
+    typeof browserCrypto.getRandomValues === 'undefined'
+  ) {
     return Buffer.from(nodeCrypto.randomBytes(size));
   } else {
     browserCrypto.getRandomValues(arr);

--- a/browser.js
+++ b/browser.js
@@ -47,10 +47,7 @@ not, since the functions are different and does
 not convert using browserify */
 function randomBytes(size) {
   var arr = new Uint8Array(size);
-  if (
-    typeof browserCrypto === 'undefined' ||
-    typeof browserCrypto.getRandomValues === 'undefined'
-  ) {
+  if (typeof browserCrypto.getRandomValues === 'undefined') {
     return Buffer.from(nodeCrypto.randomBytes(size));
   } else {
     browserCrypto.getRandomValues(arr);


### PR DESCRIPTION
This library can work in a react-native environment that uses rn-nodeify to support NodeJS crypto modules (which is very common in most projects)

The only change necessary is to check if browserCrypto or browserCrypto.getRandomValues is undefined on the randomBytes instead of checking if window is undefined. The reason for this is that  window may be polyfill'd for other reasons but WebCrypto is usually not.