### PR TITLE
Added support for arm64 node-gyp compiling for EC2 graviton compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -49,6 +49,13 @@
                 }
               }
             ],
+            [
+              "target_arch=='arm64'", {
+                "variables": {
+                  "openssl_config_path": "<(nodedir)/deps/openssl/config/arm"
+                }
+              }
+            ],
           ],
           "include_dirs": [
             "<(nodedir)/deps/openssl/openssl/include",


### PR DESCRIPTION
I added arm64 target to the binding.gyp so it will properly compile on arm64/Amazon EC2 graviton instance.