### PR TITLE
Update nan to make lib compatible with node 16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "acorn": "7.1.1",
     "elliptic": "6.5.4",
     "es6-promise": "4.2.8",
-    "nan": "2.14.0"
+    "nan": "2.17.0"
   },
   "optionalDependencies": {
     "secp256k1": "3.7.1"


### PR DESCRIPTION
Due to some API changes in node, "nan 2.14.0" is not compatible with node 16+, so native implementation of secp256k1 won't be available for node 16+. "nan 2.17.0" has no breaking changes and it's compatible with node 16+ so we can easily use it.