### PR TITLE
Fix Incorrect Usage of bn.js API in browser.js and Ensure Backward Compatibility for Decryption

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -36,7 +36,7 @@ function equalConstTime(b1, b2) {
     return false;
   }
   var res = 0;
-  for (var i = 0; i < b1.length; i += 1) {
+  for (var i = 0; i < b1.length; i++) {
     res |= b1[i] ^ b2[i];  // jshint ignore:line
   }
   return res === 0;

--- a/browser.js
+++ b/browser.js
@@ -236,7 +236,7 @@ var derive = exports.derive = function(privateKeyA, publicKeyB) {
     var keyA = ec.keyFromPrivate(privateKeyA);
     var keyB = ec.keyFromPublic(publicKeyB);
     var Px = keyA.derive(keyB.getPublic());  // BN instance
-    resolve(Px.toBuffer(undefined, 32));
+    resolve(Buffer.from(Px.toArray(undefined, 32)));
   });
 };
 

--- a/browser.js
+++ b/browser.js
@@ -36,7 +36,7 @@ function equalConstTime(b1, b2) {
     return false;
   }
   var res = 0;
-  for (var i = 0; i < b1.length; i++) {
+  for (var i = 0; i < b1.length; i += 1) {
     res |= b1[i] ^ b2[i];  // jshint ignore:line
   }
   return res === 0;
@@ -112,6 +112,40 @@ function hmacSha256Verify(key, msg, sig) {
     var expectedSig = hmac.digest();
     resolve(equalConstTime(expectedSig, sig));
   });
+}
+
+function trimBufferZeros(buf) {
+  var i = 0;
+  while (!buf[i] && i < buf.length) {
+    i += 1;
+  }
+  return buf.slice(i);
+}
+
+function decryptWithDerivedKey(privateKey, opts, Px, trimZeros) {
+  if (trimZeros) {
+    Px = trimBufferZeros(Px);
+  }
+  // Tmp variable to save context from flat promises;
+  var encryptionKey;
+  return sha512(Px)
+      .then(function (hash) {
+        encryptionKey = hash.slice(0, 32);
+        var macKey = hash.slice(32);
+        var dataToMac = Buffer.concat([
+          opts.iv,
+          opts.ephemPublicKey,
+          opts.ciphertext,
+        ]);
+        return hmacSha256Verify(macKey, dataToMac, opts.mac);
+      })
+      .then(function (macGood) {
+        assert(macGood, "Bad MAC");
+        return aesCbcDecrypt(opts.iv, encryptionKey, opts.ciphertext);
+      })
+      .then(function (msg) {
+        return Buffer.from(new Uint8Array(msg));
+      });
 }
 
 /**
@@ -202,7 +236,7 @@ var derive = exports.derive = function(privateKeyA, publicKeyB) {
     var keyA = ec.keyFromPrivate(privateKeyA);
     var keyB = ec.keyFromPublic(publicKeyB);
     var Px = keyA.derive(keyB.getPublic());  // BN instance
-    resolve(Buffer.from(Px.toArray()));
+    resolve(Px.toBuffer(undefined, 32));
   });
 };
 
@@ -241,24 +275,14 @@ exports.encrypt = function(publicKeyTo, msg, opts) {
 };
 
 exports.decrypt = function(privateKey, opts) {
-  // Tmp variable to save context from flat promises;
-  var encryptionKey;
   return derive(privateKey, opts.ephemPublicKey).then(function(Px) {
-    return sha512(Px);
-  }).then(function(hash) {
-    encryptionKey = hash.slice(0, 32);
-    var macKey = hash.slice(32);
-    var dataToMac = Buffer.concat([
-      opts.iv,
-      opts.ephemPublicKey,
-      opts.ciphertext
-    ]);
-    return hmacSha256Verify(macKey, dataToMac, opts.mac);
-  }).then(function(macGood) {
-    assert(macGood, "Bad MAC");
-    return aesCbcDecrypt(opts.iv, encryptionKey, opts.ciphertext);
-  }).then(function(msg) {
-    return Buffer.from(new Uint8Array(msg));
+    return decryptWithDerivedKey(privateKey, opts, Px, false)
+        .catch(function(err) {
+          if (!Px[0]) {
+            return decryptWithDerivedKey(privateKey, opts, Px, true);
+          }
+          return Promise.reject(err);
+        });
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function equalConstTime(b1, b2) {
     return false;
   }
   var res = 0;
-  for (var i = 0; i < b1.length; i += 1) {
+  for (var i = 0; i < b1.length; i++) {
     res |= b1[i] ^ b2[i];  // jshint ignore:line
   }
   return res === 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eccrypto",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eccrypto",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eccrypto",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "JavaScript Elliptic curve cryptography library",
   "main": "index.js",
   "browser": "browser.js",

--- a/test.js
+++ b/test.js
@@ -23,6 +23,9 @@ privateKeyB.fill(3);
 var publicKeyB = eccrypto.getPublic(privateKeyB);
 var publicKeyBCompressed = eccrypto.getPublicCompressed(privateKeyB);
 
+var privateKeyC = Buffer.from('bec50b320f17a60422a95619579675badf32c404289cb7bfa0b033b82ac17d98', 'hex');
+var publicKeyC = eccrypto.getPublic(privateKeyC);
+
 describe("Key conversion", function() {
   it("should allow to convert private key to public", function() {
     expect(Buffer.isBuffer(publicKey)).to.be.true;
@@ -158,6 +161,13 @@ describe("ECDH", function() {
         expect(Px2.length).to.equal(32);
         expect(bufferEqual(Px, Px2)).to.be.true;
       });
+    });
+  });
+
+  it("should derive 32 byte long shared secret from privkey C and pubkey C", function() {
+    return eccrypto.derive(privateKeyC, publicKeyC).then(function(Px) {
+      expect(Buffer.isBuffer(Px)).to.be.true;
+      expect(Px.length).to.equal(32);
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -263,6 +263,19 @@ describe("ECIES", function() {
         });
   });
 
+  it("should decrypt message with bad derived key", function() {
+    var sk = Buffer.from('2794d25fbfbd98c91182f3357f779d742c9cb87636d50c91159c3fc62e08a2fc', 'hex');
+    var opts = {
+      iv: Buffer.from('2ab47869855480ae9f533d7a759e0bff', 'hex'),
+      ephemPublicKey: Buffer.from('0424a921276ecd28c2f752a5588fbbadefe978ea215998dc8baf6adb092bc22ecf2b01f908c2251383349e70c16fac6b5ba9c2e39775098fec70bbd0e0744b7cb8', 'hex'),
+      ciphertext: Buffer.from('98cf08e2152ecf53ce8294adb00d1deb', 'hex'),
+      mac: Buffer.from('38b895e9837b371d901f13b39cb0b8c09f27228935d98bf49e249368a6e2dd9f', 'hex'),
+    };
+    return eccrypto.decrypt(sk, opts).then(function(msg) {
+      expect(msg.toString()).to.equal("hello world!");
+    });
+  });
+
 
   it("should reject promise on bad private key when decrypting", function(done) {
     eccrypto.encrypt(publicKeyA, Buffer.from("test")).then(function(enc) {


### PR DESCRIPTION
This PR addresses an incorrect usage of the bn.js library within browser.js on the master branch, specifically in how BN objects are converted to buffers. The existing code uses `Px.toArray()` method, which can lead to variable length byte arrays, potentially causing inconsistent behavior:

```javascript
// Current incorrect implementation
resolve(Buffer.from(Px.toArray()));
```

To ensure consistent byte array lengths, we should leverage `Buffer.from(Px.toArray(undefined, 32))` method, specifying a fixed output length. The proposed change is as follows:

```javascript
// Corrected implementation
resolve(Buffer.from(Px.toArray(undefined, 32)));
```

This modification guarantees that the conversion yields a buffer of a fixed size, mitigating issues encountered with variable length arrays.

Additionally, this PR introduces a backward compatibility layer for decrypting messages encrypted with previously derived incorrect keys. The solution attempts decryption using the corrected key length; should this fail, it then falls back to the previously incorrect key length by trimming leading zeros. This dual-path approach ensures that both newly encrypted messages and those encrypted under the prior flawed logic remain accessible.

**Related Issues**: This fix is in response to issues encountered by users, documented in #90, #81, #63,  and #52 providing a comprehensive solution to the encryption key length inconsistencies observed.